### PR TITLE
v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v2] - 12/29/2024
+
+### General
+
+- Changed default OUTPUT from `dist/` to `build`
+- INPUT now gets copied to `build/tmp` for build script.
+- Compiled packs are now stored in `build/libs`
+
+## [v1] - 12/19/2024
+
+### General
+
+initial release

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This action compiles your addon or pack into an installable file.
 - Automatically creates a `contents.json` file listing all files included in the pack.
 - Minifies all JSON files to reduce file size.
 - Handles behavior packs, resource packs, and skin packs.
-- Automatically excludes files specified in `.gitignore` and other temporary files.
 - Enable detailed logging for debugging purposes.
 
 ## Usage
@@ -75,6 +74,9 @@ def build():
 
     log.info("Starting pack build with args: %s", args)
 
+    # Adds output.txt to behavior pack
+    with open('behavior_pack/output.txt', 'w') as fd:
+      fd.write('Hello, World!')
 ```
 
 ## inputs

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   output:
     description: The directory to place the built artifacts
     required: false
-    default: "dist/"
+    default: "build"
   outputPattern:
     description: The name of the compiled file.
     required: false
@@ -41,7 +41,7 @@ runs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install gitfiles==1.0.0 mcaddon==0.0.3 commentjson==0.9.0
+        pip install -r $GITHUB_ACTION_PATH/src/requirements.txt
       shell: bash
 
     # Install dependencies from requirements.txt if it exists
@@ -64,4 +64,4 @@ runs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: v${{ fromJSON(steps.build_mcpack_action.outputs.packs)[0].version }}
-        files: dist/*
+        files: ${{ inputs.output }}/libs/*

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,3 @@
+gitfiles==1.0.0
+mcaddon==0.0.3
+commentjson==0.9.0


### PR DESCRIPTION
## General

- Changed default OUTPUT from `dist/` to `build`
- INPUT now gets copied to `build/tmp` for build script.
- Compiled packs are now stored in `build/libs`
